### PR TITLE
update utility.cpp--let the hardwareListSize >=1

### DIFF
--- a/SystemInfo/util/utility.cpp
+++ b/SystemInfo/util/utility.cpp
@@ -167,22 +167,32 @@ UINT32 getInfoBoxItemCount(UINT32 ITEM_ID, SystemInfo *info) {
 	switch (ITEM_ID) {
 		case GPU_INFO: {
 			hardwareListSize = info->getGPUDevices().size();
+			if(hardwareListSize==0)
+				hardwareListSize=1;
 			break;
 		}
 		case MONITOR_INFO: {
 			hardwareListSize = info->getDisplayDevices().size();
+			if(hardwareListSize==0)
+				hardwareListSize=1;
 			break;
 		}
 		case STORAGE_INFO: {
 			hardwareListSize = info->getStorageMediums().size();
+			if(hardwareListSize==0)
+				hardwareListSize=1;
 			break;
 		}
 		case OPTICAL_INFO: {
 			hardwareListSize = info->getCDROMDevices().size();
+			if(hardwareListSize==0)
+				hardwareListSize=1;
 			break;
 		}
 		case NETWORK_INFO: {
 			hardwareListSize = info->getNetworkAdaptersText().size();
+			if(hardwareListSize==0)
+				hardwareListSize=1;
 			break;
 		}
 		default: {


### PR DESCRIPTION
when a computer has not a GPU, monitor, storage, optical, network like me (my computer has not optical), the result should show "GPU not detect" in windows GUI but it show null . because the variable "hardwareListSize"  is  0 , it is not provide the region for test-result to show.